### PR TITLE
Fix setup.py build dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[aliases]
+test=pytest
+
 [metadata]
 description-file = README.rst
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import setuptools
 
 # To prevent importing about and thereby breaking the coverage info we use this
@@ -14,6 +15,10 @@ else:
     long_description = 'See http://pypi.python.org/pypi/python-utils/'
 
 
+needs_pytest = set(['ptr', 'pytest', 'test']).intersection(sys.argv)
+pytest_runner = ['pytest-runner'] if needs_pytest else []
+
+
 if __name__ == '__main__':
     setuptools.setup(
         name=about['__package_name__'],
@@ -27,7 +32,7 @@ if __name__ == '__main__':
         long_description=long_description,
         install_requires=['six'],
         tests_require=['pytest'],
-        setup_requires=['pytest-runner'],
+        setup_requires=[] + pytest_runner,
         classifiers=['License :: OSI Approved :: BSD License'],
     )
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ basepython =
     pypy: pypy
 deps = -r{toxinidir}/tests/requirements.txt
 
-commands = python setup.py pytest {posargs}
+commands = python setup.py test {posargs}
 
 [testenv:flake8]
 basepython = python2.7


### PR DESCRIPTION
If you only want to use `python setup.py build`, this change makes its dependencies correct (similar to https://github.com/WoLpH/python-progressbar/pull/171).