### PR TITLE
Adds remap function to converters.py

### DIFF
--- a/python_utils/converters.py
+++ b/python_utils/converters.py
@@ -234,3 +234,56 @@ def scale_1024(x, n_prefixes):
     scaled = float(x) / (2 ** (10 * power))
     return scaled, power
 
+
+def remap(value, old_min, old_max, new_min, new_max):
+    """
+    remap a value from one range into another.
+
+    >>> remap(500, 0, 1000, 0, 100)
+    50
+    >>> remap(250.0, 0.0, 1000.0, 0.0, 100.0)
+    25.0
+    >>> remap(-75, -100, 0, -1000, 0)
+    -750
+    >>> remap(33, 0, 100, -500, 500)
+    -170
+
+    This is a great use case example. Take an AVR that has dB values the minimum being -80dB and the maximum
+    being 10dB and you want to convert volume percent to the equilivint in that dB range
+
+    >>> remap(46.0, 0.0, 100.0, -80.0, 10.0)
+    -38.6
+
+    :param value: value to be converted
+    :type value: int, float
+
+    :param old_min: minimum of the range for the value that has been passed
+    :type old_min: int, float
+
+    :param old_max: maximum of the range for the value that has been passed
+    :type old_max: int, float
+
+    :param new_min: the minimum of the new range
+    :type new_min: int, float
+
+    :param new_max: the maximum of the new range
+    :type new_max: int, float
+
+    :return: value that has been re ranged, if the value is an int floor division is used so the
+        returned value will always be rounded down to the closest whole number.
+    :rtype: int, float
+    """
+    old_range = old_max - old_min
+    new_range = new_max - new_min
+    if new_range == 0:
+        return 0
+
+    if old_range == 0:
+        new_value = new_min
+    else:
+        if isinstance(value, int):
+            new_value = (((value - old_min) * new_range) // old_range) + new_min
+        else:
+            new_value = (((value - old_min) * new_range) / old_range) + new_min
+
+    return new_value


### PR DESCRIPTION
maps a int/float within a given range to the value within a new range.

great example is an AVR that uses dB's
min = -80dB
max = 10dB

and you want to convert a percentage (0-100) to the dB for that percentage

```python
from __future__ import print_function
from python_utils.converters import remap

print(remap(46.0, 0.0, 100.0, -80.0, 10.0))
```
the output is
```python
-38.6
```

It handles negative and positive integers and floats of any combination. There is handling of the new range being 0 (0 gets returned) and also the old range being 0 (minimum of the new range is returned)