### PR TITLE
Add Power Support ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,31 @@ matrix:
       env: TOXENV=py39
     - python: 'pypy'
       env: TOXENV=pypy
+  # Added power support architecture
+    - arch: ppc64le
+      python: '3.6'
+      env: TOXENV=docs
+    - arch: ppc64le
+      python: '3.6'
+      env: TOXENV=flake8
+    - arch: ppc64le
+      python: '2.7'
+      env: TOXENV=py27
+    - arch: ppc64le
+      python: '3.5'
+      env: TOXENV=py35
+    - arch: ppc64le
+      python: '3.6'
+      env: TOXENV=py36
+    - arch: ppc64le
+      python: '3.7'
+      env: TOXENV=py37
+    - arch: ppc64le
+      python: '3.8'
+      env: TOXENV=py38
+    - arch: ppc64le
+      python: '3.9-dev'
+      env: TOXENV=py39
 
 cache:
   directories:


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. 