### PR TITLE
do not install a global 'tests' package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ if __name__ == '__main__':
         description=about['__description__'],
         url=about['__url__'],
         license='BSD',
-        packages=setuptools.find_packages(),
+        packages=setuptools.find_packages(exclude=['tests']),
         long_description=long_description,
         install_requires=['six'],
         tests_require=['pytest'],


### PR DESCRIPTION
setuptools.find_packages() finds all valid packages by default that
incidentally includes the test directory that gets installed as global
'tests'.  Add an explicit exclude to avoid that.