### PR TITLE
Install only python_utils as package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ if __name__ == '__main__':
         description=about['__description__'],
         url=about['__url__'],
         license='BSD',
-        packages=setuptools.find_packages(),
+        packages=setuptools.find_packages(include=['python_utils']),
         long_description=long_description,
         install_requires=['six'],
         tests_require=['pytest'],


### PR DESCRIPTION
setup.py:
Provide an include list for `setuptools.find_packages()` [1], which is called
within `setuptools.setup()`'s `packages` parameter.
This prevents the tests being picked up as a package and installed
top-level in the site-packages directory (conflicting with other
packages, that also make this mistake).

Fixes #11

[1] https://packaging.python.org/guides/distributing-packages-using-setuptools/#packages