### PR TITLE
Refactor Logged class __new__ method return type annotation

### DIFF
--- a/python_utils/logger.py
+++ b/python_utils/logger.py
@@ -331,7 +331,7 @@ class Logged(LoggerBase):
             LoggerBase._LoggerBase__get_name(*name_parts),  # type: ignore[attr-defined]  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType, reportAttributeAccessIssue]
         )
 
-    def __new__(cls, *args: types.Any, **kwargs: types.Any):
+    def __new__(cls, *args: types.Any, **kwargs: types.Any) -> types.Self:
         """
         Create a new instance of the class and initialize the logger.
 

--- a/python_utils/logger.py
+++ b/python_utils/logger.py
@@ -331,7 +331,7 @@ class Logged(LoggerBase):
             LoggerBase._LoggerBase__get_name(*name_parts),  # type: ignore[attr-defined]  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType, reportAttributeAccessIssue]
         )
 
-    def __new__(cls, *args: types.Any, **kwargs: types.Any) -> 'Logged':
+    def __new__(cls, *args: types.Any, **kwargs: types.Any):
         """
         Create a new instance of the class and initialize the logger.
 


### PR DESCRIPTION
This pull request makes a minor update to the `__new__` method signature in `python_utils/logger.py`, removing the unnecessary explicit return type annotation. 

The explicit type-hint over-constrained the return to Logged instances also for derived classes. Therefore, instantiation of derived class tricked the type-checker to thinking it was instantiating a Logged instance, instead of the an instance of the derived class.